### PR TITLE
Add `nix` expressions to build `proto3-wire`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, base, bytestring, cereal, containers, deepseq
+, QuickCheck, safe, semigroups, stdenv, tasty, tasty-hunit
+, tasty-quickcheck, text
+}:
+mkDerivation {
+  pname = "proto3-wire";
+  version = "1.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    base bytestring cereal containers deepseq QuickCheck safe text
+  ];
+  testHaskellDepends = [
+    base bytestring cereal QuickCheck semigroups tasty tasty-hunit
+    tasty-quickcheck text
+  ];
+  description = "A low-level implementation of the Protocol Buffers (version 3) wire format";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,4 @@
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc7102" }:
+{   proto3-wire =
+        nixpkgs.pkgs.haskell.packages.${compiler}.callPackage ./default.nix { };
+}

--- a/release.nix
+++ b/release.nix
@@ -1,4 +1,4 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc7102" }:
+{ pkgs ? import <nixpkgs> {}, compiler ? "ghc7102" }:
 {   proto3-wire =
-        nixpkgs.pkgs.haskell.packages.${compiler}.callPackage ./default.nix { };
+        pkgs.haskell.packages.${compiler}.callPackage ./default.nix { };
 }


### PR DESCRIPTION
The purpose of this is two-fold:

* (A) give people a way to build `proto3-wire` using `nix`
* (B) Let us test this repository using `nix`'s `hydra` server as the CI

I've already validated that this builds using our internal `hydra` server

The `default.nix` file was auto-generated using `cabal2nix .` and any time the project dependencies change you can regenerate the file