### PR TITLE
Fail to decode non-protobuf bytes

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -19,6 +19,7 @@
 module Main where
 
 import qualified Data.ByteString.Lazy  as BL
+import           Data.Either           ( isLeft )
 import           Data.Maybe            ( fromMaybe )
 import           Data.Semigroup        ( (<>) )
 import qualified Data.Text.Lazy        as T
@@ -120,4 +121,4 @@ roundTrip name encode decode =
 decodeNonsense :: TestTree
 decodeNonsense = HU.testCase "Decoding a nonsensical string fails." $ do
   let decoded = Decode.parse (one Decode.fixed64 0 `at` fieldNumber 1) "test"
-  decoded HU.@?= Left (Decode.BinaryError "Failed reading: Encountered bytes that aren't valid key/value pairs.\nEmpty call stack\n")
+  HU.assertBool "decode fails" $ isLeft decoded

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -120,4 +120,4 @@ roundTrip name encode decode =
 decodeNonsense :: TestTree
 decodeNonsense = HU.testCase "Decoding a nonsensical string fails." $ do
   let decoded = Decode.parse (one Decode.fixed64 0 `at` fieldNumber 1) "test"
-  decoded HU.@?= Left (Decode.WireTypeError "foo")
+  decoded HU.@?= Left (Decode.BinaryError "Failed reading: Encountered bytes that aren't valid key/value pairs.\nEmpty call stack\n")

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -14,6 +14,8 @@
   limitations under the License.
 -}
 
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
 import qualified Data.ByteString.Lazy  as BL
@@ -35,7 +37,8 @@ main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
-tests = testGroup "Tests" [ roundTripTests ]
+tests = testGroup "Tests" [ roundTripTests
+                            , decodeNonsense ]
 
 roundTripTests :: TestTree
 roundTripTests = testGroup "Roundtrip tests"
@@ -113,3 +116,8 @@ roundTrip name encode decode =
             case Decode.parse decode (BL.toStrict bytes) of
                 Left _ -> error "Could not decode encoded message"
                 Right x' -> x === x'
+
+decodeNonsense :: TestTree
+decodeNonsense = HU.testCase "Decoding a nonsensical string fails." $ do
+  let decoded = Decode.parse (one Decode.fixed64 0 `at` fieldNumber 1) "test"
+  decoded HU.@?= Left (Decode.WireTypeError "foo")


### PR DESCRIPTION
Previously, the parser would parse invalid messages to empty messages. This PR makes the parser fail on invalid input, by checking that there are no bytes left to consume after consuming all key-value pairs in the message.