### PR TITLE
Add Travis support (via Nix)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: nix
+script: nix-build release.nix

--- a/release.nix
+++ b/release.nix
@@ -1,6 +1,6 @@
 let config = {
   packageOverrides = pkgs: {
-    haskellPackages = pkgs.haskellPackages.override {
+    haskellPackages = pkgs.haskell.packages.ghc7103.override {
       overrides = haskellPackagesNew: haskellPackagesOld: {
         proto3-wire = haskellPackagesOld.callPackage ./default.nix { };
       };

--- a/release.nix
+++ b/release.nix
@@ -1,4 +1,13 @@
-{ pkgs ? import <nixpkgs> {}, compiler ? "ghc7102" }:
-{   proto3-wire =
-        pkgs.haskell.packages.${compiler}.callPackage ./default.nix { };
-}
+let config = {
+  packageOverrides = pkgs: {
+    haskellPackages = pkgs.haskellPackages.override {
+      overrides = haskellPackagesNew: haskellPackagesOld: {
+        proto3-wire = haskellPackagesOld.callPackage ./default.nix { };
+      };
+    };
+  };
+};
+in
+
+{ pkgs ? import <nixpkgs> { inherit config; } }:
+pkgs.haskellPackages.proto3-wire


### PR DESCRIPTION
This adds Travis CI support for `proto3-wire` using `nix`.  Besides adding CI, this also ensures that the `nix` build expression doesn't get out of sync with the `.cabal` file

This also requires enabling Travis for this repository (which I can't do because I'm not an admin for `proto3-wire`).  However, I test drove this on my own fork of the repository with Travis enabled so that you can see what the Travis integration looks like:

https://github.com/Gabriel439/proto3-wire/pull/1