### PR TITLE
Fix `release.nix` to be in a `hydra`-compatible format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: nix
-script: nix-build release.nix
+script: nix-channel --remove nixpkgs && nix-channel --add https://nixos.org/channels/nixos-16.03/ nixpkgs && nix-channel --update && nix-build release.nix

--- a/release.nix
+++ b/release.nix
@@ -10,4 +10,5 @@ let config = {
 in
 
 { pkgs ? import <nixpkgs> { inherit config; } }:
-pkgs.haskellPackages.proto3-wire
+{ proto3-wire = pkgs.haskellPackages.proto3-wire;
+}


### PR DESCRIPTION
`hydra` expects the build expression to be a set of build products instead of
just a single derivation

`nix-build` is still compatible with this set format, too, so we don't need to
change `travis`