### PR TITLE
Use a stable NixOS channel in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: nix
-script: nix-build release.nix
+script: nix-channel --remove nixpkgs && nix-channel --add https://nixos.org/channels/nixos-16.03/ nixpkgs && nix-channel --update && nix-build release.nix


### PR DESCRIPTION
`master` broke without any changes due to using the unstable channel in CI.  This
request changes CI to first install the `nixos-16.03` stable channel before
building