### PR TITLE
Fix slow nested calls to 'embedded'.

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -39,7 +39,6 @@ test-suite tests
                        cereal >= 0.5.1 && <0.6,
                        proto3-wire,
                        QuickCheck >=2.8 && <2.9,
-                       semigroups ==0.18.*,
                        tasty >= 0.11 && <0.12,
                        tasty-hunit >= 0.9 && <0.10,
                        tasty-quickcheck >= 0.8.4 && <0.9,

--- a/src/Proto3/Wire/Encode.hs
+++ b/src/Proto3/Wire/Encode.hs
@@ -104,9 +104,10 @@ toLazyByteString :: Builder -> BL.ByteString
 toLazyByteString (Builder (Sum len, bb)) =
     BB.toLazyByteStringWith strat BL.empty bb
   where
-    -- If the supplied length is accurate then we will perform
-    -- just one allocation.  Any inaccuracy would indicate
-    -- a bug in one of the primitives that produces a 'Builder'.
+    -- If the supplied length is accurate then we will perform just
+    -- one allocation (unless that length exceeds 'maxFirstChunk').
+    -- An inaccurate length would indicate a bug in
+    -- one of the primitives that produces a 'Builder'.
     maxFirstChunk = 134217728  -- 128MiB
     firstChunk = fromIntegral (min maxFirstChunk len)
     strat = BB.safeStrategy firstChunk BB.defaultChunkSize

--- a/src/Proto3/Wire/Encode.hs
+++ b/src/Proto3/Wire/Encode.hs
@@ -16,15 +16,15 @@
 
 -- | Low level functions for writing the protobufs wire format.
 --
--- Because protobuf messages are encoded as a collection of fields, one
--- can use the 'Monoid' instance for 'BB.Builder' to encode multiple
+-- Because protobuf messages are encoded as a collection of fields,
+-- one can use the 'Monoid' instance for 'Builder' to encode multiple
 -- fields.
 --
 -- One should be careful to make sure that 'FieldNumber's appear in
 -- increasing order.
 --
 -- In protocol buffers version 3, all fields are optional. To omit a value
--- for a field, simply do not append it to the 'BB.Builder'. One can
+-- for a field, simply do not append it to the 'Builder'. One can
 -- create functions for wrapping optional fields with a 'Maybe' type.
 --
 -- Similarly, repeated fields can be encoded by concatenating several values
@@ -32,12 +32,13 @@
 --
 -- For example:
 --
--- > strings :: Foldable f => FieldNumber -> f String -> BB.Builder
+-- > strings :: Foldable f => FieldNumber -> f String -> Builder
 -- > strings = foldMap . string
 -- >
 -- > fieldNumber 1 `strings` Just "some string" <>
 -- > fieldNumber 2 `strings` [ "foo", "bar", "baz" ]
 
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Proto3.Wire.Encode
@@ -72,25 +73,80 @@ module Proto3.Wire.Encode
     , packedFloats
     , packedDoubles
       -- * Reexports
-    , BB.Builder
-    , BB.toLazyByteString
+    , Builder
+    , builderLength
+    , toLazyByteString
     ) where
 
-import           Data.Bits                   ( (.&.), (.|.), shiftL, shiftR, xor )
-import qualified Data.ByteString             as B
-import qualified Data.ByteString.Builder     as BB
-import qualified Data.ByteString.Lazy        as BL
-import           Data.Int                    ( Int32, Int64 )
-import           Data.Monoid                 ( (<>) )
-import qualified Data.Text.Lazy              as Text.Lazy
-import qualified Data.Text.Lazy.Encoding     as Text.Lazy.Encoding
-import           Data.Word                   ( Word32, Word64, Word8 )
+import           Data.Bits                     ( (.&.), (.|.), shiftL, shiftR, xor )
+import qualified Data.ByteString               as B
+import qualified Data.ByteString.Builder       as BB
+import qualified Data.ByteString.Builder.Extra as BB
+import qualified Data.ByteString.Lazy          as BL
+import           Data.Char                     ( ord )
+import           Data.Int                      ( Int32, Int64 )
+import           Data.Monoid                   ( Sum(..), (<>) )
+import qualified Data.Text.Encoding            as Text.Encoding
+import qualified Data.Text.Lazy                as Text.Lazy
+import qualified Data.Text.Lazy.Encoding       as Text.Lazy.Encoding
+import           Data.Word                     ( Word32, Word64, Word8 )
 import           Proto3.Wire.Types
 
-base128Varint :: Word64 -> BB.Builder
+-- | Like 'BB.Builder', but memoizes the resulting length so
+-- that we can efficiently encode nested embedded messages.
+newtype Builder = Builder { unBuilder :: (Sum Word, BB.Builder) }
+  deriving Monoid
+
+builderLength :: Builder -> Word
+builderLength = getSum . fst . unBuilder
+
+toLazyByteString :: Builder -> BL.ByteString
+toLazyByteString (Builder (Sum len, bb)) =
+    BB.toLazyByteStringWith strat BL.empty bb
+  where
+    -- If the supplied length is accurate then we will perform
+    -- just one allocation.  Any inaccuracy would indicate
+    -- a bug in one of the primitives that produces a 'Builder'.
+    maxFirstChunk = 134217728  -- 128MiB
+    firstChunk = fromIntegral (min maxFirstChunk len)
+    strat = BB.safeStrategy firstChunk BB.defaultChunkSize
+{-# NOINLINE toLazyByteString #-}
+
+word8 :: Word8 -> Builder
+word8 w = Builder (Sum 1, BB.word8 w)
+
+word32LE :: Word32 -> Builder
+word32LE w = Builder (Sum 4, BB.word32LE w)
+
+int32LE :: Int32 -> Builder
+int32LE w = Builder (Sum 4, BB.int32LE w)
+
+floatLE :: Float -> Builder
+floatLE f = Builder (Sum 4, BB.floatLE f)
+
+word64LE :: Word64 -> Builder
+word64LE w = Builder (Sum 8, BB.word64LE w)
+
+int64LE :: Int64 -> Builder
+int64LE w = Builder (Sum 8, BB.int64LE w)
+
+doubleLE :: Double -> Builder
+doubleLE f = Builder (Sum 8, BB.doubleLE f)
+
+stringUtf8 :: String -> Builder
+stringUtf8 s = Builder (Sum (len 0 s), BB.stringUtf8 s)
+  where
+    len !n []      = n
+    len !n (h : t) = case ord h of
+      c | c <= 0x7F   -> len (n + 1) t
+        | c <= 0x07FF -> len (n + 2) t
+        | c <= 0xFFFF -> len (n + 3) t
+        | otherwise   -> len (n + 4) t
+
+base128Varint :: Word64 -> Builder
 base128Varint i
-    | i .&. 0x7f == i = BB.word8 (fromIntegral i)
-    | otherwise = BB.word8 (0x80 .|. (fromIntegral i .&. 0x7f)) <>
+    | i .&. 0x7f == i = word8 (fromIntegral i)
+    | otherwise = word8 (0x80 .|. (fromIntegral i .&. 0x7f)) <>
           base128Varint (i `shiftR` 7)
 
 wireType :: WireType -> Word8
@@ -99,7 +155,7 @@ wireType Fixed32 = 5
 wireType Fixed64 = 1
 wireType LengthDelimited = 2
 
-fieldHeader :: FieldNumber -> WireType -> BB.Builder
+fieldHeader :: FieldNumber -> WireType -> Builder
 fieldHeader num wt = base128Varint ((getFieldNumber num `shiftL` 3) .|.
                                         fromIntegral (wireType wt))
 
@@ -108,7 +164,7 @@ fieldHeader num wt = base128Varint ((getFieldNumber num `shiftL` 3) .|.
 -- For example:
 --
 -- > fieldNumber 1 `int32` 42
-int32 :: FieldNumber -> Int32 -> BB.Builder
+int32 :: FieldNumber -> Int32 -> Builder
 int32 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 
 -- | Encode a 64-bit "standard" integer
@@ -116,7 +172,7 @@ int32 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 -- For example:
 --
 -- > fieldNumber 1 `int64` negate 42
-int64 :: FieldNumber -> Int64 -> BB.Builder
+int64 :: FieldNumber -> Int64 -> Builder
 int64 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 
 -- | Encode a 32-bit unsigned integer
@@ -124,7 +180,7 @@ int64 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 -- For example:
 --
 -- > fieldNumber 1 `uint32` 42
-uint32 :: FieldNumber -> Word32 -> BB.Builder
+uint32 :: FieldNumber -> Word32 -> Builder
 uint32 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 
 -- | Encode a 64-bit unsigned integer
@@ -132,7 +188,7 @@ uint32 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 -- For example:
 --
 -- > fieldNumber 1 `uint64` 42
-uint64 :: FieldNumber -> Word64 -> BB.Builder
+uint64 :: FieldNumber -> Word64 -> Builder
 uint64 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 
 -- | Encode a 32-bit signed integer
@@ -140,7 +196,7 @@ uint64 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 -- For example:
 --
 -- > fieldNumber 1 `sint32` negate 42
-sint32 :: FieldNumber -> Int32 -> BB.Builder
+sint32 :: FieldNumber -> Int32 -> Builder
 sint32 num i = int32 num ((i `shiftL` 1) `xor` (i `shiftR` 31))
 
 -- | Encode a 64-bit signed integer
@@ -148,7 +204,7 @@ sint32 num i = int32 num ((i `shiftL` 1) `xor` (i `shiftR` 31))
 -- For example:
 --
 -- > fieldNumber 1 `sint64` negate 42
-sint64 :: FieldNumber -> Int64 -> BB.Builder
+sint64 :: FieldNumber -> Int64 -> Builder
 sint64 num i = int64 num ((i `shiftL` 1) `xor` (i `shiftR` 63))
 
 -- | Encode a fixed-width 32-bit integer
@@ -156,48 +212,48 @@ sint64 num i = int64 num ((i `shiftL` 1) `xor` (i `shiftR` 63))
 -- For example:
 --
 -- > fieldNumber 1 `fixed32` 42
-fixed32 :: FieldNumber -> Word32 -> BB.Builder
-fixed32 num i = fieldHeader num Fixed32 <> BB.word32LE i
+fixed32 :: FieldNumber -> Word32 -> Builder
+fixed32 num i = fieldHeader num Fixed32 <> word32LE i
 
 -- | Encode a fixed-width 64-bit integer
 --
 -- For example:
 --
 -- > fieldNumber 1 `fixed64` 42
-fixed64 :: FieldNumber -> Word64 -> BB.Builder
-fixed64 num i = fieldHeader num Fixed64 <> BB.word64LE i
+fixed64 :: FieldNumber -> Word64 -> Builder
+fixed64 num i = fieldHeader num Fixed64 <> word64LE i
 
 -- | Encode a fixed-width signed 32-bit integer
 --
 -- For example:
 --
 -- > fieldNumber 1 `sfixed32` negate 42
-sfixed32 :: FieldNumber -> Int32 -> BB.Builder
-sfixed32 num i = fieldHeader num Fixed32 <> BB.int32LE i
+sfixed32 :: FieldNumber -> Int32 -> Builder
+sfixed32 num i = fieldHeader num Fixed32 <> int32LE i
 
 -- | Encode a fixed-width signed 64-bit integer
 --
 -- For example:
 --
 -- > fieldNumber 1 `sfixed64` negate 42
-sfixed64 :: FieldNumber -> Int64 -> BB.Builder
-sfixed64 num i = fieldHeader num Fixed64 <> BB.int64LE i
+sfixed64 :: FieldNumber -> Int64 -> Builder
+sfixed64 num i = fieldHeader num Fixed64 <> int64LE i
 
 -- | Encode a floating point number
 --
 -- For example:
 --
 -- > fieldNumber 1 `float` 3.14
-float :: FieldNumber -> Float -> BB.Builder
-float num f = fieldHeader num Fixed32 <> BB.floatLE f
+float :: FieldNumber -> Float -> Builder
+float num f = fieldHeader num Fixed32 <> floatLE f
 
 -- | Encode a double-precision number
 --
 -- For example:
 --
 -- > fieldNumber 1 `double` 3.14
-double :: FieldNumber -> Double -> BB.Builder
-double num d = fieldHeader num Fixed64 <> BB.doubleLE d
+double :: FieldNumber -> Double -> Builder
+double num d = fieldHeader num Fixed64 <> doubleLE d
 
 -- | Encode a value with an enumerable type.
 --
@@ -211,7 +267,7 @@ double num d = fieldHeader num Fixed64 <> BB.doubleLE d
 -- >
 -- > fieldNumber 1 `enum` True <>
 -- > fieldNumber 2 `enum` Circle
-enum :: Enum e => FieldNumber -> e -> BB.Builder
+enum :: Enum e => FieldNumber -> e -> Builder
 enum num e = fieldHeader num Varint <> base128Varint (fromIntegral (fromEnum e))
 
 -- | Encode a UTF-8 string.
@@ -219,53 +275,62 @@ enum num e = fieldHeader num Varint <> base128Varint (fromIntegral (fromEnum e))
 -- For example:
 --
 -- > fieldNumber 1 `string` "testing"
-string :: FieldNumber -> String -> BB.Builder
-string num = embedded num . BB.stringUtf8
+string :: FieldNumber -> String -> Builder
+string num = embedded num . stringUtf8
 
 -- | Encode lazy `Text` as UTF-8
 --
 -- For example:
 --
 -- > fieldNumber 1 `text` "testing"
-text :: FieldNumber -> Text.Lazy.Text -> BB.Builder
-text num txt = embedded num
-                        (BB.lazyByteString (Text.Lazy.Encoding.encodeUtf8 txt))
+text :: FieldNumber -> Text.Lazy.Text -> Builder
+text num txt =
+    embedded num (Builder (Sum len, Text.Lazy.Encoding.encodeUtf8Builder txt))
+  where
+    -- It would be nice to avoid actually allocating encoded chunks,
+    -- but we leave that enhancement for a future time.
+    len = Text.Lazy.foldrChunks op 0 txt
+    op chnk acc = fromIntegral (B.length (Text.Encoding.encodeUtf8 chnk)) + acc
 
 -- | Encode a collection of bytes in the form of a strict 'B.ByteString'.
 --
 -- For example:
 --
 -- > fieldNumber 1 `byteString` fromString "some bytes"
-byteString :: FieldNumber -> B.ByteString -> BB.Builder
-byteString num = embedded num . BB.byteString
+byteString :: FieldNumber -> B.ByteString -> Builder
+byteString num bs = embedded num bldr
+  where
+    bldr = (Builder (Sum (fromIntegral (B.length bs)), BB.byteString bs))
 
 -- | Encode a lazy bytestring.
 --
 -- For example:
 --
 -- > fieldNumber 1 `lazyByteString` fromString "some bytes"
-lazyByteString :: FieldNumber -> BL.ByteString -> BB.Builder
-lazyByteString num = embedded num . BB.lazyByteString
+lazyByteString :: FieldNumber -> BL.ByteString -> Builder
+lazyByteString num bl = embedded num bldr
+  where
+    bldr = (Builder (Sum (fromIntegral (BL.length bl)), BB.lazyByteString bl))
 
 -- | Encode varints in the space-efficient packed format.
-packedVarints :: Foldable f => FieldNumber -> f Word64 -> BB.Builder
+packedVarints :: Foldable f => FieldNumber -> f Word64 -> Builder
 packedVarints num = embedded num . foldMap base128Varint
 
 -- | Encode fixed-width Word32s in the space-efficient packed format.
-packedFixed32 :: Foldable f => FieldNumber -> f Word32 -> BB.Builder
-packedFixed32 num = embedded num . foldMap BB.word32LE
+packedFixed32 :: Foldable f => FieldNumber -> f Word32 -> Builder
+packedFixed32 num = embedded num . foldMap word32LE
 
 -- | Encode fixed-width Word64s in the space-efficient packed format.
-packedFixed64 :: Foldable f => FieldNumber -> f Word64 -> BB.Builder
-packedFixed64 num = embedded num . foldMap BB.word64LE
+packedFixed64 :: Foldable f => FieldNumber -> f Word64 -> Builder
+packedFixed64 num = embedded num . foldMap word64LE
 
 -- | Encode floats in the space-efficient packed format.
-packedFloats :: Foldable f => FieldNumber -> f Float -> BB.Builder
-packedFloats num = embedded num . foldMap BB.floatLE
+packedFloats :: Foldable f => FieldNumber -> f Float -> Builder
+packedFloats num = embedded num . foldMap floatLE
 
 -- | Encode doubles in the space-efficient packed format.
-packedDoubles :: Foldable f => FieldNumber -> f Double -> BB.Builder
-packedDoubles num = embedded num . foldMap BB.doubleLE
+packedDoubles :: Foldable f => FieldNumber -> f Double -> Builder
+packedDoubles num = embedded num . foldMap doubleLE
 
 -- | Encode an embedded message.
 --
@@ -277,9 +342,7 @@ packedDoubles num = embedded num . foldMap BB.doubleLE
 -- > embedded (fieldNumber 1) $
 -- >   fieldNumber (fieldNumber 1) `string` "this message" <>
 -- >   fieldNumber (fieldNumber 2) `string` " is embedded"
-embedded :: FieldNumber -> BB.Builder -> BB.Builder
+embedded :: FieldNumber -> Builder -> Builder
 embedded num bb = fieldHeader num LengthDelimited <>
-    base128Varint (fromIntegral len) <>
+    base128Varint (fromIntegral (builderLength bb)) <>
     bb
-  where
-    len = BL.length (BB.toLazyByteString bb)

--- a/src/Proto3/Wire/Tutorial.hs
+++ b/src/Proto3/Wire/Tutorial.hs
@@ -47,7 +47,7 @@
 -- To encode an 'EchoRequest', we use the @Encode.'Encode.text'@ function, and provide
 -- the field number and the text value:
 --
--- > encodeEchoRequest :: EchoRequest -> Builder
+-- > encodeEchoRequest :: EchoRequest -> Encode.Builder
 -- > encodeEchoRequest EchoRequest{..} =
 -- >     Encode.text (fieldNumber 1) echoRequestMessage
 --
@@ -92,11 +92,11 @@
 --
 -- == Encoding
 --
--- To encode messages with multiple fields, note that functions in the "Proto3.Wire.Encode"
--- module return values in the 'Builder' monoid, so we can use `mappend` to
--- combine messages:
+-- To encode messages with multiple fields, note that functions in the
+-- "Proto3.Wire.Encode" module return values in the 'Encode.Builder' monoid,
+-- so we can use `mappend` to combine messages:
 --
--- > encodedEchoResponse :: EchoResponse -> Builder
+-- > encodedEchoResponse :: EchoResponse -> Encode.Builder
 -- > encodedEchoResponse EchoResponse{..} =
 -- >     Encode.text (fieldNumber 1) echoResponseMessage <>
 -- >         Encode.uint64 (fieldNumber 2) echoResponseTimestamp
@@ -136,14 +136,14 @@
 -- Messages can be embedded using `Encode.embedded`.
 --
 -- In protocol buffers version 3, all fields are optional. To omit a value for a
--- field, simply do not append it to the 'Builder'.
+-- field, simply do not append it to the 'Encode.Builder'.
 --
 -- Similarly, repeated fields can be encoded by concatenating several values
 -- with the same 'FieldNumber'.
 --
 -- It can be useful to use 'foldMap' to deal with these cases.
 --
--- > encodeEchoManyRequest :: EchoManyRequest -> Builder
+-- > encodeEchoManyRequest :: EchoManyRequest -> Encode.Builder
 -- > encodeEchoManyRequest =
 -- >   foldMap (Encode.embedded (fieldNumber 1) . encodeEchoRequest)
 -- >   . echoManyRequestRequests
@@ -168,7 +168,6 @@
 module Proto3.Wire.Tutorial where
 
 import           Data.ByteString         ( ByteString )
-import           Data.ByteString.Builder ( Builder )
 import           Data.Monoid             ( (<>) )
 import           Data.Sequence           ( Seq )
 import           Data.Text.Lazy          ( Text )
@@ -180,7 +179,7 @@ import qualified Proto3.Wire.Decode      as Decode
 
 data EchoRequest = EchoRequest { echoRequestMessage :: Text }
 
-encodeEchoRequest :: EchoRequest -> Builder
+encodeEchoRequest :: EchoRequest -> Encode.Builder
 encodeEchoRequest EchoRequest{..} =
     Encode.text (fieldNumber 1) echoRequestMessage
 
@@ -194,7 +193,7 @@ data EchoResponse = EchoResponse { echoResponseMessage   :: Text
                                  , echoResponseTimestamp :: Word64
                                  }
 
-encodedEchoResponse :: EchoResponse -> Builder
+encodedEchoResponse :: EchoResponse -> Encode.Builder
 encodedEchoResponse EchoResponse{..} =
     Encode.text (fieldNumber 1) echoResponseMessage <>
         Encode.uint64 (fieldNumber 2) echoResponseTimestamp
@@ -209,7 +208,7 @@ echoResponseParser = EchoResponse <$> (one Decode.text mempty `at` fieldNumber 1
 data EchoManyRequest = EchoManyRequest { echoManyRequestRequests :: Seq EchoRequest
                                        }
 
-encodeEchoManyRequest :: EchoManyRequest -> Builder
+encodeEchoManyRequest :: EchoManyRequest -> Encode.Builder
 encodeEchoManyRequest = foldMap (Encode.embedded (fieldNumber 1) .
                                      encodeEchoRequest) .
     echoManyRequestRequests

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -21,7 +21,7 @@ module Main where
 import qualified Data.ByteString.Lazy  as BL
 import           Data.Either           ( isLeft )
 import           Data.Maybe            ( fromMaybe )
-import           Data.Semigroup        ( (<>) )
+import           Data.Monoid           ( (<>) )
 import qualified Data.Text.Lazy        as T
 
 import           Proto3.Wire


### PR DESCRIPTION
It is common to nest calls to `Proto3.Wire.Encode.embedded`.

But that function computed the length of the embedded message by
executing its builder to produce a temporary lazy `ByteString`.

Therefore when you run the builder returned by `embedded`, you
indirectly run its argument builder twice.  And if that builder
is itself produced by `embedded`, then the situation worsens.
The more deeply nested the data, the worse the performance.

This commit memoizes the number of bytes produced by each builder,
so that data structures being encoded are traversed only twice,
no matter the depth of nested calls to `embedded`: once to compute
the length of the encoding, and again to emit the encoding.

That is the theory, anyway.  Empirically, consider the test that
would be produced by applying the patch included below.  We observed
this commit to reduce the time required for that test from 3.42 seconds
to 0.01 seconds.  Of course, the nesting level is deeper than you would
see in typical practice, but it does illustrate the point.  Please note
that we are not actually checking in this test, because it never fails,
and adding some kind of performance testing framework seems like overkill.

```
diff --git a/proto3-wire.cabal b/proto3-wire.cabal
index bf33a16..3d4782a 100644
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -44,3 +44,4 @@ test-suite tests
                        tasty-hunit >= 0.9 && <0.10,
                        tasty-quickcheck >= 0.8.4 && <0.9,
                        text >= 0.2 && <1.3
+  ghc-options:         -O2
diff --git a/test/Main.hs b/test/Main.hs
index cae12da..1ee130a 100644
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -39,7 +39,9 @@ main = defaultMain tests

 tests :: TestTree
 tests = testGroup "Tests" [ roundTripTests
-                            , decodeNonsense ]
+                          , decodeNonsense
+                          , performance
+                          ]

 roundTripTests :: TestTree
 roundTripTests = testGroup "Roundtrip tests"
@@ -122,3 +124,10 @@ decodeNonsense :: TestTree
 decodeNonsense = HU.testCase "Decoding a nonsensical string fails." $ do
   let decoded = Decode.parse (one Decode.fixed64 0 `at` fieldNumber 1) "test"
   HU.assertBool "decode fails" $ isLeft decoded
+
+performance :: TestTree
+performance = HU.testCase "Performance." $ do
+  let builder 0 = Encode.byteString 0 "foo"
+      builder n = Encode.embedded (FieldNumber n) (builder (n - 1))
+  BL.foldrChunks seq (return ()) (Encode.toLazyByteString (builder 10000))
+  HU.assertBool "always succeeds" $ True
```