### PR TITLE
relax QuickCheck bounds

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -24,7 +24,7 @@ library
                        deepseq ==1.4.*,
                        safe ==0.3.*,
                        text >= 0.2 && <1.3,
-                       QuickCheck >=2.8 && <2.9
+                       QuickCheck >=2.8 && <3.0
 
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -39,7 +39,7 @@ test-suite tests
                        bytestring >=0.10.6.0 && <0.11.0,
                        cereal >= 0.5.1 && <0.6,
                        proto3-wire,
-                       QuickCheck >=2.8 && <2.9,
+                       QuickCheck >=2.8 && <3.0,
                        tasty >= 0.11 && <0.12,
                        tasty-hunit >= 0.9 && <0.10,
                        tasty-quickcheck >= 0.8.4 && <0.9,


### PR DESCRIPTION
For a `grpc-haskell` change.