### PR TITLE
Add documentation and doctests to `Proto3.Wire.Builder`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 { mkDerivation, base, bytestring, cereal, containers, deepseq
-, QuickCheck, safe, stdenv, tasty, tasty-hunit, tasty-quickcheck
-, text
+, doctest, QuickCheck, safe, stdenv, tasty, tasty-hunit
+, tasty-quickcheck, text
 }:
 mkDerivation {
   pname = "proto3-wire";
@@ -10,7 +10,7 @@ mkDerivation {
     base bytestring cereal containers deepseq QuickCheck safe text
   ];
   testHaskellDepends = [
-    base bytestring cereal QuickCheck tasty tasty-hunit
+    base bytestring cereal doctest QuickCheck tasty tasty-hunit
     tasty-quickcheck text
   ];
   description = "A low-level implementation of the Protocol Buffers (version 3) wire format";

--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -38,6 +38,7 @@ test-suite tests
   build-depends:       base >=4.8 && <=5.0,
                        bytestring >=0.10.6.0 && <0.11.0,
                        cereal >= 0.5.1 && <0.6,
+                       doctest >= 0.7.0 && <0.12,
                        proto3-wire,
                        QuickCheck >=2.8 && <3.0,
                        tasty >= 0.11 && <0.12,

--- a/src/Proto3/Wire/Builder.hs
+++ b/src/Proto3/Wire/Builder.hs
@@ -14,18 +14,23 @@
   limitations under the License.
 -}
 
--- | Extends "Data.ByteString.Builder" by memoizing the resulting length.
+-- | This module extends the "Data.ByteString.Builder" module by memoizing the
+-- resulting length of each `Builder`
+--
+-- Example use:
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (word32BE 42 <> charUtf8 'λ'))
+-- [0,0,0,42,206,187]
 
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Proto3.Wire.Builder
-    ( Builder
-    , builderLength
-    , rawBuilder
-    , unsafeMakeBuilder
-    , toLazyByteString
-    , hPutBuilder
+    (
+      -- * `Builder` type
+      Builder
+
+      -- * Create `Builder`s
     , byteString
     , lazyByteString
     , shortByteString
@@ -53,6 +58,15 @@ module Proto3.Wire.Builder
     , string8
     , charUtf8
     , stringUtf8
+
+      -- * Consume `Builder`s
+    , builderLength
+    , rawBuilder
+    , toLazyByteString
+    , hPutBuilder
+
+    -- * Internal API
+    , unsafeMakeBuilder
     ) where
 
 import qualified Data.ByteString               as B
@@ -66,22 +80,67 @@ import           Data.Monoid                   ( Sum(..) )
 import           Data.Word                     ( Word8, Word16, Word32, Word64 )
 import           System.IO                     ( Handle )
 
--- | Like 'BB.Builder', but memoizes the resulting length so
--- that we can efficiently encode nested embedded messages.
+-- $setup
+-- >>> :set -XOverloadedStrings
+-- >>> import Data.Monoid
+
+-- | A `Builder` is like a @"Data.ByteString.Builder".`BB.Builder`@, but also
+-- memoizes the resulting length so that we can efficiently encode nested
+-- embedded messages.
+--
+-- You create a `Builder` by using one of the primitives provided in the
+-- \"Create `Builder`s\" section
+--
+-- You combine `Builder`s using the `Monoid` instance
+--
+-- You consume a `Builder` by using one of the utilities provided in the
+-- \"Consume `Builder`s\" section
 newtype Builder = Builder { unBuilder :: (Sum Word, BB.Builder) }
   deriving Monoid
 
+-- | Retrieve the length of a `Builder`
+--
+-- > builderLength (x <> y) = builderLength x + builderLength y
+-- >
+-- > builderLength mempty = 0
+--
+-- >>> builderLength (word32BE 42)
+-- 4
+-- >>> builderLength (stringUtf8 "ABC")
+-- 3
 builderLength :: Builder -> Word
 builderLength = getSum . fst . unBuilder
 
+-- | Retrieve the underlying @"Data.ByteString.Builder".`BB.Builder`@
+--
+-- > rawBuilder (x <> y) = rawBuilder x <> rawBuilder y
+-- >
+-- > rawBuilder mempty = mempty
+--
+-- >>> Data.ByteString.Builder.toLazyByteString (rawBuilder (stringUtf8 "ABC"))
+-- "ABC"
 rawBuilder :: Builder -> BB.Builder
 rawBuilder = snd . unBuilder
 
--- | Use with caution--the caller is responsible for ensuring that
--- the given length figure accurately measures the given builder.
+-- | Create a `Builder` from a @"Data.ByteString.Builder".`BB.Builder`@ and a
+-- length.  This is unsafe because you are responsible for ensuring that the
+-- provided length value matches the length of the
+-- @"Data.ByteString.Builder".`BB.Builder`@
+--
+-- >>> let builder = unsafeMakeBuilder 3 (Data.ByteString.Builder.stringUtf8 "ABC")
+-- >>> toLazyByteString builder
+-- "ABC"
 unsafeMakeBuilder :: Word -> BB.Builder -> Builder
 unsafeMakeBuilder len bldr = Builder (Sum len, bldr)
 
+-- | Create a lazy `BL.ByteString` from a `Builder`
+--
+-- > toLazyByteString (x <> y) = toLazyByteString x <> toLazyByteString y
+-- >
+-- > toLazyByteString mempty = mempty
+--
+-- >>> toLazyByteString (stringUtf8 "ABC")
+-- "ABC"
 toLazyByteString :: Builder -> BL.ByteString
 toLazyByteString (Builder (Sum len, bb)) =
     BB.toLazyByteStringWith strat BL.empty bb
@@ -93,91 +152,322 @@ toLazyByteString (Builder (Sum len, bb)) =
 {-# NOINLINE toLazyByteString #-}
   -- NOINLINE to avoid bloating caller; see docs for 'BB.toLazyByteStringWith'.
 
+-- | Write a `Builder` to a `Handle`
+--
+-- > hPutBuilder handle (x <> y) = hPutBuilder handle x <> hPutBuilder handle y
+-- >
+-- > hPutBuilder handle mempty = mempty
+--
+-- >>> hPutBuilder System.IO.stdout (stringUtf8 "ABC\n")
+-- ABC
 hPutBuilder :: Handle -> Builder -> IO ()
 hPutBuilder handle = BB.hPutBuilder handle . snd . unBuilder
 
+-- | Convert a strict `B.ByteString` to a `Builder`
+--
+-- > byteString (x <> y) = byteString x <> byteString y
+-- >
+-- > byteString mempty = mempty
+--
+-- >>> toLazyByteString (byteString "ABC")
+-- "ABC"
 byteString :: B.ByteString -> Builder
 byteString bs = Builder (Sum (fromIntegral (B.length bs)), BB.byteString bs)
 
--- | Warning: evaluating the length will generate the input chunks,
+-- | Convert a lazy `BL.ByteString` to a `Builder`
+--
+-- Warning: evaluating the length will force the lazy `BL.ByteString`'s chunks,
 -- and they will remain allocated until you finish using the builder.
+--
+-- > lazyByteString (x <> y) = lazyByteString x <> lazyByteString y
+-- >
+-- > lazyByteString mempty = mempty
+--
+-- > lazyByteString . toLazyByteString = id
+-- >
+-- > toLazyByteString . lazyByteString = id
+--
+-- >>> toLazyByteString (lazyByteString "ABC")
+-- "ABC"
 lazyByteString :: BL.ByteString -> Builder
 lazyByteString bl =
   Builder (Sum (fromIntegral (BL.length bl)), BB.lazyByteString bl)
 
+-- | Convert a `BS.ShortByteString` to a `Builder`
+--
+-- > shortByteString (x <> y) = shortByteString x <> shortByteString y
+-- >
+-- > shortByteString mempty = mempty
+--
+-- >>> toLazyByteString (shortByteString "ABC")
+-- "ABC"
 shortByteString :: BS.ShortByteString -> Builder
 shortByteString bs =
   Builder (Sum (fromIntegral (BS.length bs)), BB.shortByteString bs)
 
+-- | Convert a `Word8` to a `Builder`
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (word8 42))
+-- [42]
 word8 :: Word8 -> Builder
 word8 w = Builder (Sum 1, BB.word8 w)
 
+-- | Convert a `Int8` to a `Builder`
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (int8 (-5)))
+-- [251]
 int8 :: Int8 -> Builder
 int8 w = Builder (Sum 1, BB.int8 w)
 
+-- | Convert a `Word16` to a `Builder` by storing the bytes in big-endian order
+--
+-- In other words, the most significant byte is stored first and the least
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (word16BE 42))
+-- [0,42]
 word16BE :: Word16 -> Builder
 word16BE w = Builder (Sum 2, BB.word16BE w)
 
+-- | Convert a `Word16` to a `Builder` by storing the bytes in little-endian
+-- order
+--
+-- In other words, the least significant byte is stored first and the most
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (word16LE 42))
+-- [42,0]
 word16LE :: Word16 -> Builder
 word16LE w = Builder (Sum 2, BB.word16LE w)
 
+-- | Convert an `Int16` to a `Builder` by storing the bytes in big-endian order
+--
+-- In other words, the most significant byte is stored first and the least
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (int16BE (-5)))
+-- [255,251]
 int16BE :: Int16 -> Builder
 int16BE w = Builder (Sum 2, BB.int16BE w)
 
+-- | Convert an `Int16` to a `Builder` by storing the bytes in little-endian
+-- order
+--
+-- In other words, the least significant byte is stored first and the most
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (int16LE (-5)))
+-- [251,255]
 int16LE :: Int16 -> Builder
 int16LE w = Builder (Sum 2, BB.int16LE w)
 
+-- | Convert a `Word32` to a `Builder` by storing the bytes in big-endian order
+--
+-- In other words, the most significant byte is stored first and the least
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (word32BE 42))
+-- [0,0,0,42]
 word32BE :: Word32 -> Builder
 word32BE w = Builder (Sum 4, BB.word32BE w)
 
+-- | Convert a `Word32` to a `Builder` by storing the bytes in little-endian
+-- order
+--
+-- In other words, the least significant byte is stored first and the most
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (word32LE 42))
+-- [42,0,0,0]
 word32LE :: Word32 -> Builder
 word32LE w = Builder (Sum 4, BB.word32LE w)
 
+-- | Convert an `Int32` to a `Builder` by storing the bytes in big-endian order
+--
+-- In other words, the most significant byte is stored first and the least
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (int32BE (-5)))
+-- [255,255,255,251]
 int32BE :: Int32 -> Builder
 int32BE w = Builder (Sum 4, BB.int32BE w)
 
+-- | Convert an `Int32` to a `Builder` by storing the bytes in little-endian
+-- order
+--
+-- In other words, the least significant byte is stored first and the most
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (int32LE (-5)))
+-- [251,255,255,255]
 int32LE :: Int32 -> Builder
 int32LE w = Builder (Sum 4, BB.int32LE w)
 
+-- | Convert a `Float` to a `Builder` by storing the bytes in IEEE-754 format in
+-- big-endian order
+--
+-- In other words, the most significant byte is stored first and the least
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (floatBE 4.2))
+-- [64,134,102,102]
 floatBE :: Float -> Builder
 floatBE f = Builder (Sum 4, BB.floatBE f)
 
+-- | Convert a `Float` to a `Builder` by storing the bytes in IEEE-754 format in
+-- little-endian order
+--
+-- In other words, the least significant byte is stored first and the most
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (floatLE 4.2))
+-- [102,102,134,64]
 floatLE :: Float -> Builder
 floatLE f = Builder (Sum 4, BB.floatLE f)
 
+-- | Convert a `Word64` to a `Builder` by storing the bytes in big-endian order
+--
+-- In other words, the most significant byte is stored first and the least
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (word64BE 42))
+-- [0,0,0,0,0,0,0,42]
 word64BE :: Word64 -> Builder
 word64BE w = Builder (Sum 8, BB.word64BE w)
 
+-- | Convert a `Word64` to a `Builder` by storing the bytes in little-endian
+-- order
+--
+-- In other words, the least significant byte is stored first and the most
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (word64LE 42))
+-- [42,0,0,0,0,0,0,0]
 word64LE :: Word64 -> Builder
 word64LE w = Builder (Sum 8, BB.word64LE w)
 
+-- | Convert an `Int64` to a `Builder` by storing the bytes in big-endian order
+--
+-- In other words, the most significant byte is stored first and the least
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (int64BE (-5)))
+-- [255,255,255,255,255,255,255,251]
 int64BE :: Int64 -> Builder
 int64BE w = Builder (Sum 8, BB.int64BE w)
 
+-- | Convert an `Int64` to a `Builder` by storing the bytes in little-endian
+-- order
+--
+-- In other words, the least significant byte is stored first and the most
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (int64LE (-5)))
+-- [251,255,255,255,255,255,255,255]
 int64LE :: Int64 -> Builder
 int64LE w = Builder (Sum 8, BB.int64LE w)
 
+-- | Convert a `Double` to a `Builder` by storing the bytes in IEEE-754 format
+-- in big-endian order
+--
+-- In other words, the most significant byte is stored first and the least
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (doubleBE 4.2))
+-- [64,16,204,204,204,204,204,205]
 doubleBE :: Double -> Builder
 doubleBE f = Builder (Sum 8, BB.doubleBE f)
 
+-- | Convert a `Double` to a `Builder` by storing the bytes in IEEE-754 format
+-- in little-endian order
+--
+-- In other words, the least significant byte is stored first and the most
+-- significant byte is stored last
+--
+-- >>> Data.ByteString.Lazy.unpack (toLazyByteString (doubleLE 4.2))
+-- [205,204,204,204,204,204,16,64]
 doubleLE :: Double -> Builder
 doubleLE f = Builder (Sum 8, BB.doubleLE f)
 
+-- | Convert an @ASCII@ `Char` to a `Builder`
+--
+-- __Careful:__ If you provide a Unicode character that is not part of the
+-- @ASCII@ alphabet this will only encode the lowest 7 bits
+--
+-- >>> toLazyByteString (char7 ';')
+-- ";"
+-- >>> toLazyByteString (char7 'λ') -- Example of truncation
+-- ";"
 char7 :: Char -> Builder
 char7 c = Builder (Sum 1, BB.char7 c)
 
+-- | Convert an @ASCII@ `String` to a `Builder`
+--
+-- __Careful:__ If you provide a Unicode `String` that has non-@ASCII@
+-- characters then this will only encode the lowest 7 bits of each character
+--
+-- > string7 (x <> y) = string7 x <> string7 y
+-- >
+-- > string7 mempty = mempty
+--
+-- >>> toLazyByteString (string7 "ABC")
+-- "ABC"
+-- >>> toLazyByteString (string7 "←↑→↓") -- Example of truncation
+-- "\DLE\DC1\DC2\DC3"
 string7 :: String -> Builder
 string7 s = Builder (Sum (fromIntegral (length s)), BB.string7 s)
 
+-- | Convert an @ISO/IEC 8859-1@ `Char` to a `Builder`
+--
+-- __Careful:__ If you provide a Unicode character that is not part of the
+-- @ISO/IEC 8859-1@ alphabet then this will only encode the lowest 8 bits
+--
+-- >>> toLazyByteString (char8 ';')
+-- ";"
+-- >>> toLazyByteString (char8 'λ') -- Example of truncation
+-- "\187"
 char8 :: Char -> Builder
 char8 c = Builder (Sum 1, BB.char8 c)
 
+-- | Convert an @ISO/IEC 8859-1@ `String` to a `Builder`
+--
+-- __Careful:__ If you provide a Unicode `String` that has non-@ISO/IEC 8859-1@
+-- characters then this will only encode the lowest 8 bits of each character
+--
+-- > string8 (x <> y) = string8 x <> string8 y
+-- >
+-- > string8 mempty = mempty
+--
+-- >>> toLazyByteString (string8 "ABC")
+-- "ABC"
+-- >>> toLazyByteString (string8 "←↑→↓") -- Example of truncation
+-- "\144\145\146\147"
 string8 :: String -> Builder
 string8 s = Builder (Sum (fromIntegral (length s)), BB.string8 s)
 
+-- | Convert a Unicode `Char` to a `Builder` using a @UTF-8@ encoding
+--
+-- >>> toLazyByteString (charUtf8 'A')
+-- "A"
+-- >>> toLazyByteString (charUtf8 'λ')
+-- "\206\187"
+-- >>> hPutBuilder System.IO.stdout (charUtf8 'λ' <> charUtf8 '\n')
+-- λ
 charUtf8 :: Char -> Builder
 charUtf8 c = Builder (Sum (utf8Width c), BB.charUtf8 c)
 
+-- | Convert a Unicode `String` to a `Builder` using a @UTF-8@ encoding
+--
+-- > stringUtf8 (x <> y) = stringUtf8 x <> stringUtf8 y
+-- >
+-- > stringUtf8 mempty = mempty
+--
+-- >>> toLazyByteString (stringUtf8 "ABC")
+-- "ABC"
+-- >>> toLazyByteString (stringUtf8 "←↑→↓")
+-- "\226\134\144\226\134\145\226\134\146\226\134\147"
+-- >>> hPutBuilder System.IO.stdout (stringUtf8 "←↑→↓\n")
+-- ←↑→↓
 stringUtf8 :: String -> Builder
 stringUtf8 s = Builder (Sum (len 0 s), BB.stringUtf8 s)
   where

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -28,6 +28,7 @@ import           Proto3.Wire
 import qualified Proto3.Wire.Encode    as Encode
 import qualified Proto3.Wire.Decode    as Decode
 
+import qualified Test.DocTest
 import           Test.QuickCheck       ( (===), Arbitrary )
 import           Test.Tasty
 import           Test.Tasty.HUnit      ( (@=?) )
@@ -35,7 +36,9 @@ import qualified Test.Tasty.HUnit      as HU
 import qualified Test.Tasty.QuickCheck as QC
 
 main :: IO ()
-main = defaultMain tests
+main = do
+    Test.DocTest.doctest ["src/Proto3/Wire/Builder.hs"]
+    defaultMain tests
 
 tests :: TestTree
 tests = testGroup "Tests" [ roundTripTests


### PR DESCRIPTION
This expands the documentation of the `Proto3.Wire.Builder` and adds
documentation tests which are checked by a new `doctest` addition to the
test suite