### PR TITLE
Fix `getFields` to handle interleaved repeated fields

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,14 @@
 { mkDerivation, base, bytestring, cereal, containers, deepseq
-, doctest, QuickCheck, safe, stdenv, tasty, tasty-hunit
-, tasty-quickcheck, text
+, doctest, hashable, QuickCheck, safe, stdenv, tasty, tasty-hunit
+, tasty-quickcheck, text, unordered-containers
 }:
 mkDerivation {
   pname = "proto3-wire";
   version = "1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    base bytestring cereal containers deepseq QuickCheck safe text
+    base bytestring cereal containers deepseq hashable QuickCheck safe
+    text unordered-containers
   ];
   testHaskellDepends = [
     base bytestring cereal doctest QuickCheck tasty tasty-hunit

--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -22,8 +22,10 @@ library
                        cereal >= 0.5.1 && <0.6,
                        containers ==0.5.*,
                        deepseq ==1.4.*,
+                       hashable <1.3,
                        safe ==0.3.*,
                        text >= 0.2 && <1.3,
+                       unordered-containers >= 0.1.0.0 && <0.3,
                        QuickCheck >=2.8 && <3.0
 
   hs-source-dirs:      src

--- a/src/Proto3/Wire/Types.hs
+++ b/src/Proto3/Wire/Types.hs
@@ -30,6 +30,7 @@ module Proto3.Wire.Types
     ) where
 
 import           Control.DeepSeq ( NFData )
+import           Data.Hashable   ( Hashable )
 import           Data.Word       ( Word64 )
 import           Test.QuickCheck ( Arbitrary(..), choose )
 
@@ -39,7 +40,7 @@ import           Test.QuickCheck ( Arbitrary(..), choose )
 -- sure that field numbers are provided in increasing order. Such things are
 -- left to other, higher-level libraries.
 newtype FieldNumber = FieldNumber { getFieldNumber :: Word64 }
-    deriving (Show, Eq, Ord, Enum, NFData, Num)
+    deriving (Show, Eq, Ord, Enum, Hashable, NFData, Num)
 
 instance Arbitrary FieldNumber where
   arbitrary = fmap FieldNumber $ choose (1, 536870911)


### PR DESCRIPTION
`getFields` groups fields by key but does not sort by the key first,
meaning that if the keys are ordered like this:

```
[(k1, v1), (k2, v2), (k1, v3)]
```

... then the second occurrence of `k1` will be dropped instead of
collected with the first occurrence of `k1`.

In addition to fixing the algorithm to occur non-contiguous repetitions
this also speeds up the grouping code.  After benchmarking a wide
variety of algorithms to sort and group values by key, the fastest algorithm
was to use `Data.HashMap.fromListWith`.  This converts the `HashMap` to a
`Map` to preserve the original API and there is no loss of performance
due to this conversion.