### PR TITLE
Change `Show` implementation for `FieldNumber`

### DIFF
--- a/src/Proto3/Wire/Types.hs
+++ b/src/Proto3/Wire/Types.hs
@@ -39,7 +39,10 @@ import           Test.QuickCheck ( Arbitrary(..), choose )
 -- sure that field numbers are provided in increasing order. Such things are
 -- left to other, higher-level libraries.
 newtype FieldNumber = FieldNumber { getFieldNumber :: Word64 }
-    deriving (Show, Eq, Ord, Enum, NFData, Num)
+    deriving (Eq, Ord, Enum, NFData, Num)
+
+instance Show FieldNumber where
+    show (FieldNumber n) = show n
 
 instance Arbitrary FieldNumber where
   arbitrary = fmap FieldNumber $ choose (1, 536870911)


### PR DESCRIPTION
The derived `Show` instance for `FieldNumber` is more verbose than
necessary.  This change takes advantage of the fact that `FieldNumber`
implements `Num` so that the `Show` implementation can display just a
numeric literal.  This is still valid code for building a `FieldNumber`.