### PR TITLE
Consolidate `Builder` types

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -37,7 +37,11 @@ import qualified Test.Tasty.QuickCheck as QC
 
 main :: IO ()
 main = do
-    Test.DocTest.doctest ["src/Proto3/Wire/Builder.hs"]
+    Test.DocTest.doctest
+      [ "-isrc"
+      , "src/Proto3/Wire/Builder.hs"
+      , "src/Proto3/Wire/Encode.hs"
+      ]
     defaultMain tests
 
 tests :: TestTree


### PR DESCRIPTION
The `proto3-wire` library provided two new `Builder` types in these
modules:

*   `Proto3.Wire.Builder`

    This `Builder` implementation wraps
    `Data.ByteString.Builder.Builder` to provide efficient length
    lookups

*   `Proto3.Wire.Encoded`

    This `Builder` implementation is just a `newtype` wrapper around
    `Proto3.Wire.Builder.Builder`

This pull request removes the latter `Builder` type and reuses the
former one, for a few reasons:

* The latter `Builder` type has no `Show` instance and can't have one
  because the exposed primitives do not suffice because there is no
  public API to generate an arbitrary such `Builder`
* The presence of two new `Builder` types in the library might confuse
  new users
* This consolidates their documentation

The main advantage of offering a second `Builder` type is to not expose
utilities for assembling invalid protobuf messages, but a more
lightweight solution is to just not export the `Builder` constructor
from `Proto3.Wire.Encode` and to treat `Proto3.Wire.Builder` as an
internal API for `Proto3.Wire.Encode`

This also takes advantage of the newly available `Show` instance to add
doctests in `Proto3.Wire.Encode`