### PR TITLE
Use default Haskell compiler when building with Nix

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,6 +1,6 @@
 let config = {
   packageOverrides = pkgs: {
-    haskellPackages = pkgs.haskell.packages.ghc7103.override {
+    haskellPackages = pkgs.haskellPackages.override {
       overrides = haskellPackagesNew: haskellPackagesOld: {
         proto3-wire = haskellPackagesOld.callPackage ./default.nix { };
       };


### PR DESCRIPTION
This updates `release.nix` to the default Haskell compiler supplied by
`nixpkgs` instead of pinning to GHC 7.10.3