### PR TITLE
Reintroduce `Proto3.Wire.Encode.Builder` as `Message`

### DIFF
--- a/src/Proto3/Wire/Encode.hs
+++ b/src/Proto3/Wire/Encode.hs
@@ -127,13 +127,11 @@ rawMessage = WB.rawBuilder . unMessage
 toLazyByteString :: Message -> BL.ByteString
 toLazyByteString = WB.toLazyByteString . unMessage
 
--- | This is the only utility in this module that lets you build a malformed
--- protobuf message
---
--- This lets you cast an arbitrary `ByteString` to a `Message`, whether or not
+-- | This lets you cast an arbitrary `ByteString` to a `Message`, whether or not
 -- the `ByteString` corresponds to a valid serialized protobuf message
 --
--- Do not use this function unless you know what you're doing
+-- Do not use this function unless you know what you're doing because it lets
+-- you assemble malformed protobuf `Message`s
 unsafeFromLazyByteString :: BL.ByteString -> Message
 unsafeFromLazyByteString bytes' = Message { unMessage = WB.lazyByteString bytes' }
 

--- a/src/Proto3/Wire/Encode.hs
+++ b/src/Proto3/Wire/Encode.hs
@@ -103,7 +103,7 @@ import           Proto3.Wire.Types
 -- Use the utilities provided by this module to build `Message`s
 --
 -- You can concatenate two messages using the `Monoid` instance for `Message`
--- 
+--
 -- Use `toLazyByteString` when you're done assembling the `Message`
 newtype Message = Message { unMessage :: WB.Builder }
   deriving Monoid

--- a/src/Proto3/Wire/Encode.hs
+++ b/src/Proto3/Wire/Encode.hs
@@ -17,14 +17,14 @@
 -- | Low level functions for writing the protobufs wire format.
 --
 -- Because protobuf messages are encoded as a collection of fields,
--- one can use the 'Monoid' instance for 'Message' to encode multiple
+-- one can use the 'Monoid' instance for 'MessageBuilder' to encode multiple
 -- fields.
 --
 -- One should be careful to make sure that 'FieldNumber's appear in
 -- increasing order.
 --
 -- In protocol buffers version 3, all fields are optional. To omit a value
--- for a field, simply do not append it to the 'Message'. One can
+-- for a field, simply do not append it to the 'MessageBuilder'. One can
 -- create functions for wrapping optional fields with a 'Maybe' type.
 --
 -- Similarly, repeated fields can be encoded by concatenating several values
@@ -32,7 +32,7 @@
 --
 -- For example:
 --
--- > strings :: Foldable f => FieldNumber -> f String -> Message
+-- > strings :: Foldable f => FieldNumber -> f String -> MessageBuilder
 -- > strings = foldMap . string
 -- >
 -- > 1 `strings` Just "some string" <>
@@ -41,10 +41,10 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Proto3.Wire.Encode
-    ( -- * `Message` type
-      Message
+    ( -- * `MessageBuilder` type
+      MessageBuilder
     , messageLength
-    , rawMessage
+    , rawMessageBuilder
     , toLazyByteString
     , unsafeFromLazyByteString
 
@@ -98,17 +98,18 @@ import           Proto3.Wire.Types
 --
 -- >>> :set -XOverloadedStrings
 
--- | A `Message` represents a serialized protobuf message
+-- | A `MessageBuilder` represents a serialized protobuf message
 --
--- Use the utilities provided by this module to build `Message`s
+-- Use the utilities provided by this module to create `MessageBuilder`s
 --
--- You can concatenate two messages using the `Monoid` instance for `Message`
+-- You can concatenate two messages using the `Monoid` instance for
+-- `MessageBuilder`
 --
--- Use `toLazyByteString` when you're done assembling the `Message`
-newtype Message = Message { unMessage :: WB.Builder }
+-- Use `toLazyByteString` when you're done assembling the `MessageBuilder`
+newtype MessageBuilder = MessageBuilder { unMessageBuilder :: WB.Builder }
   deriving Monoid
 
-instance Show Message where
+instance Show MessageBuilder where
   showsPrec prec builder =
       showParen (prec > 10)
         (showString "Proto3.Wire.Encode.unsafeFromLazyByteString " . shows bytes')
@@ -116,29 +117,30 @@ instance Show Message where
       bytes' = toLazyByteString builder
 
 -- | Retrieve the length of a message, in bytes
-messageLength :: Message -> Word
-messageLength = WB.builderLength . unMessage
+messageLength :: MessageBuilder -> Word
+messageLength = WB.builderLength . unMessageBuilder
 
 -- | Convert a message to a @"Data.ByteString.Builder".`BB.Builder`@
-rawMessage :: Message -> BB.Builder
-rawMessage = WB.rawBuilder . unMessage
+rawMessageBuilder :: MessageBuilder -> BB.Builder
+rawMessageBuilder = WB.rawBuilder . unMessageBuilder
 
 -- | Convert a message to a lazy `BL.ByteString`
-toLazyByteString :: Message -> BL.ByteString
-toLazyByteString = WB.toLazyByteString . unMessage
+toLazyByteString :: MessageBuilder -> BL.ByteString
+toLazyByteString = WB.toLazyByteString . unMessageBuilder
 
--- | This lets you cast an arbitrary `ByteString` to a `Message`, whether or not
--- the `ByteString` corresponds to a valid serialized protobuf message
+-- | This lets you cast an arbitrary `ByteString` to a `MessageBuilder`, whether
+-- or not the `ByteString` corresponds to a valid serialized protobuf message
 --
 -- Do not use this function unless you know what you're doing because it lets
--- you assemble malformed protobuf `Message`s
-unsafeFromLazyByteString :: BL.ByteString -> Message
-unsafeFromLazyByteString bytes' = Message { unMessage = WB.lazyByteString bytes' }
+-- you assemble malformed protobuf `MessageBuilder`s
+unsafeFromLazyByteString :: BL.ByteString -> MessageBuilder
+unsafeFromLazyByteString bytes' =
+    MessageBuilder { unMessageBuilder = WB.lazyByteString bytes' }
 
-base128Varint :: Word64 -> Message
+base128Varint :: Word64 -> MessageBuilder
 base128Varint i
-    | i .&. 0x7f == i = Message (WB.word8 (fromIntegral i))
-    | otherwise = Message (WB.word8 (0x80 .|. (fromIntegral i .&. 0x7f))) <>
+    | i .&. 0x7f == i = MessageBuilder (WB.word8 (fromIntegral i))
+    | otherwise = MessageBuilder (WB.word8 (0x80 .|. (fromIntegral i .&. 0x7f))) <>
           base128Varint (i `shiftR` 7)
 
 wireType :: WireType -> Word8
@@ -147,7 +149,7 @@ wireType Fixed32 = 5
 wireType Fixed64 = 1
 wireType LengthDelimited = 2
 
-fieldHeader :: FieldNumber -> WireType -> Message
+fieldHeader :: FieldNumber -> WireType -> MessageBuilder
 fieldHeader num wt = base128Varint ((getFieldNumber num `shiftL` 3) .|.
                                         fromIntegral (wireType wt))
 
@@ -157,7 +159,7 @@ fieldHeader num wt = base128Varint ((getFieldNumber num `shiftL` 3) .|.
 --
 -- >>> 1 `int32` 42
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\b*"
-int32 :: FieldNumber -> Int32 -> Message
+int32 :: FieldNumber -> Int32 -> MessageBuilder
 int32 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 
 -- | Encode a 64-bit "standard" integer
@@ -166,7 +168,7 @@ int32 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 --
 -- >>> 1 `int64` (-42)
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\b\214\255\255\255\255\255\255\255\255\SOH"
-int64 :: FieldNumber -> Int64 -> Message
+int64 :: FieldNumber -> Int64 -> MessageBuilder
 int64 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 
 -- | Encode a 32-bit unsigned integer
@@ -175,7 +177,7 @@ int64 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 --
 -- >>> 1 `uint32` 42
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\b*"
-uint32 :: FieldNumber -> Word32 -> Message
+uint32 :: FieldNumber -> Word32 -> MessageBuilder
 uint32 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 
 -- | Encode a 64-bit unsigned integer
@@ -184,7 +186,7 @@ uint32 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 --
 -- >>> 1 `uint64` 42
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\b*"
-uint64 :: FieldNumber -> Word64 -> Message
+uint64 :: FieldNumber -> Word64 -> MessageBuilder
 uint64 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 
 -- | Encode a 32-bit signed integer
@@ -193,7 +195,7 @@ uint64 num i = fieldHeader num Varint <> base128Varint (fromIntegral i)
 --
 -- >>> 1 `sint32` (-42)
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\bS"
-sint32 :: FieldNumber -> Int32 -> Message
+sint32 :: FieldNumber -> Int32 -> MessageBuilder
 sint32 num i = int32 num ((i `shiftL` 1) `xor` (i `shiftR` 31))
 
 -- | Encode a 64-bit signed integer
@@ -202,7 +204,7 @@ sint32 num i = int32 num ((i `shiftL` 1) `xor` (i `shiftR` 31))
 --
 -- >>> 1 `sint64` (-42)
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\bS"
-sint64 :: FieldNumber -> Int64 -> Message
+sint64 :: FieldNumber -> Int64 -> MessageBuilder
 sint64 num i = int64 num ((i `shiftL` 1) `xor` (i `shiftR` 63))
 
 -- | Encode a fixed-width 32-bit integer
@@ -211,8 +213,8 @@ sint64 num i = int64 num ((i `shiftL` 1) `xor` (i `shiftR` 63))
 --
 -- >>> 1 `fixed32` 42
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\r*\NUL\NUL\NUL"
-fixed32 :: FieldNumber -> Word32 -> Message
-fixed32 num i = fieldHeader num Fixed32 <> Message (WB.word32LE i)
+fixed32 :: FieldNumber -> Word32 -> MessageBuilder
+fixed32 num i = fieldHeader num Fixed32 <> MessageBuilder (WB.word32LE i)
 
 -- | Encode a fixed-width 64-bit integer
 --
@@ -220,16 +222,16 @@ fixed32 num i = fieldHeader num Fixed32 <> Message (WB.word32LE i)
 --
 -- >>> 1 `fixed64` 42
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\t*\NUL\NUL\NUL\NUL\NUL\NUL\NUL"
-fixed64 :: FieldNumber -> Word64 -> Message
-fixed64 num i = fieldHeader num Fixed64 <> Message (WB.word64LE i)
+fixed64 :: FieldNumber -> Word64 -> MessageBuilder
+fixed64 num i = fieldHeader num Fixed64 <> MessageBuilder (WB.word64LE i)
 
 -- | Encode a fixed-width signed 32-bit integer
 --
 -- For example:
 --
 -- > 1 `sfixed32` (-42)
-sfixed32 :: FieldNumber -> Int32 -> Message
-sfixed32 num i = fieldHeader num Fixed32 <> Message (WB.int32LE i)
+sfixed32 :: FieldNumber -> Int32 -> MessageBuilder
+sfixed32 num i = fieldHeader num Fixed32 <> MessageBuilder (WB.int32LE i)
 
 -- | Encode a fixed-width signed 64-bit integer
 --
@@ -237,8 +239,8 @@ sfixed32 num i = fieldHeader num Fixed32 <> Message (WB.int32LE i)
 --
 -- >>> 1 `sfixed64` (-42)
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\t\214\255\255\255\255\255\255\255"
-sfixed64 :: FieldNumber -> Int64 -> Message
-sfixed64 num i = fieldHeader num Fixed64 <> Message (WB.int64LE i)
+sfixed64 :: FieldNumber -> Int64 -> MessageBuilder
+sfixed64 num i = fieldHeader num Fixed64 <> MessageBuilder (WB.int64LE i)
 
 -- | Encode a floating point number
 --
@@ -246,8 +248,8 @@ sfixed64 num i = fieldHeader num Fixed64 <> Message (WB.int64LE i)
 --
 -- >>> 1 `float` 3.14
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\r\195\245H@"
-float :: FieldNumber -> Float -> Message
-float num f = fieldHeader num Fixed32 <> Message (WB.floatLE f)
+float :: FieldNumber -> Float -> MessageBuilder
+float num f = fieldHeader num Fixed32 <> MessageBuilder (WB.floatLE f)
 
 -- | Encode a double-precision number
 --
@@ -255,8 +257,8 @@ float num f = fieldHeader num Fixed32 <> Message (WB.floatLE f)
 --
 -- >>> 1 `double` 3.14
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\t\US\133\235Q\184\RS\t@"
-double :: FieldNumber -> Double -> Message
-double num d = fieldHeader num Fixed64 <> Message (WB.doubleLE d)
+double :: FieldNumber -> Double -> MessageBuilder
+double num d = fieldHeader num Fixed64 <> MessageBuilder (WB.doubleLE d)
 
 -- | Encode a value with an enumerable type.
 --
@@ -268,15 +270,15 @@ double num d = fieldHeader num Fixed64 <> Message (WB.doubleLE d)
 -- >>> data Shape = Circle | Square | Triangle deriving (Enum)
 -- >>> 1 `enum` True <> 2 `enum` Circle
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\b\SOH\DLE\NUL"
-enum :: Enum e => FieldNumber -> e -> Message
+enum :: Enum e => FieldNumber -> e -> MessageBuilder
 enum num e = fieldHeader num Varint <> base128Varint (fromIntegral (fromEnum e))
 
 -- | Encode a sequence of octets as a field of type 'bytes'.
 --
 -- >>> 1 `bytes` (Proto3.Wire.Builder.stringUtf8 "testing")
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\n\atesting"
-bytes :: FieldNumber -> WB.Builder -> Message
-bytes num = embedded num . Message
+bytes :: FieldNumber -> WB.Builder -> MessageBuilder
+bytes num = embedded num . MessageBuilder
 
 -- | Encode a UTF-8 string.
 --
@@ -284,8 +286,8 @@ bytes num = embedded num . Message
 --
 -- >>> 1 `string` "testing"
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\n\atesting"
-string :: FieldNumber -> String -> Message
-string num = embedded num . Message . WB.stringUtf8
+string :: FieldNumber -> String -> MessageBuilder
+string num = embedded num . MessageBuilder . WB.stringUtf8
 
 -- | Encode lazy `Text` as UTF-8
 --
@@ -293,9 +295,9 @@ string num = embedded num . Message . WB.stringUtf8
 --
 -- >>> 1 `text` "testing"
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\n\atesting"
-text :: FieldNumber -> Text.Lazy.Text -> Message
+text :: FieldNumber -> Text.Lazy.Text -> MessageBuilder
 text num txt =
-    embedded num (Message (WB.unsafeMakeBuilder len (Text.Lazy.Encoding.encodeUtf8Builder txt)))
+    embedded num (MessageBuilder (WB.unsafeMakeBuilder len (Text.Lazy.Encoding.encodeUtf8Builder txt)))
   where
     -- It would be nice to avoid actually allocating encoded chunks,
     -- but we leave that enhancement for a future time.
@@ -311,8 +313,8 @@ text num txt =
 --
 -- >>> 1 `byteString` "testing"
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\n\atesting"
-byteString :: FieldNumber -> B.ByteString -> Message
-byteString num bs = embedded num (Message (WB.byteString bs))
+byteString :: FieldNumber -> B.ByteString -> MessageBuilder
+byteString num bs = embedded num (MessageBuilder (WB.byteString bs))
 
 -- | Encode a lazy bytestring.
 --
@@ -320,54 +322,54 @@ byteString num bs = embedded num (Message (WB.byteString bs))
 --
 -- >>> 1 `lazyByteString` "testing"
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\n\atesting"
-lazyByteString :: FieldNumber -> BL.ByteString -> Message
-lazyByteString num bl = embedded num (Message (WB.lazyByteString bl))
+lazyByteString :: FieldNumber -> BL.ByteString -> MessageBuilder
+lazyByteString num bl = embedded num (MessageBuilder (WB.lazyByteString bl))
 
 -- | Encode varints in the space-efficient packed format.
 --
 -- >>> 1 `packedVarints` [1, 2, 3]
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\n\ETX\SOH\STX\ETX"
-packedVarints :: Foldable f => FieldNumber -> f Word64 -> Message
+packedVarints :: Foldable f => FieldNumber -> f Word64 -> MessageBuilder
 packedVarints num = embedded num . foldMap base128Varint
 
 -- | Encode fixed-width Word32s in the space-efficient packed format.
 --
 -- >>> 1 `packedFixed32` [1, 2, 3]
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\n\f\SOH\NUL\NUL\NUL\STX\NUL\NUL\NUL\ETX\NUL\NUL\NUL"
-packedFixed32 :: Foldable f => FieldNumber -> f Word32 -> Message
-packedFixed32 num = embedded num . foldMap (Message . WB.word32LE)
+packedFixed32 :: Foldable f => FieldNumber -> f Word32 -> MessageBuilder
+packedFixed32 num = embedded num . foldMap (MessageBuilder . WB.word32LE)
 
 -- | Encode fixed-width Word64s in the space-efficient packed format.
 --
 -- >>> 1 `packedFixed64` [1, 2, 3]
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\n\CAN\SOH\NUL\NUL\NUL\NUL\NUL\NUL\NUL\STX\NUL\NUL\NUL\NUL\NUL\NUL\NUL\ETX\NUL\NUL\NUL\NUL\NUL\NUL\NUL"
-packedFixed64 :: Foldable f => FieldNumber -> f Word64 -> Message
-packedFixed64 num = embedded num . foldMap (Message . WB.word64LE)
+packedFixed64 :: Foldable f => FieldNumber -> f Word64 -> MessageBuilder
+packedFixed64 num = embedded num . foldMap (MessageBuilder . WB.word64LE)
 
 -- | Encode floats in the space-efficient packed format.
 --
 -- >>> 1 `packedFloats` [1, 2, 3]
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\n\f\NUL\NUL\128?\NUL\NUL\NUL@\NUL\NUL@@"
-packedFloats :: Foldable f => FieldNumber -> f Float -> Message
-packedFloats num = embedded num . foldMap (Message . WB.floatLE)
+packedFloats :: Foldable f => FieldNumber -> f Float -> MessageBuilder
+packedFloats num = embedded num . foldMap (MessageBuilder . WB.floatLE)
 
 -- | Encode doubles in the space-efficient packed format.
 --
 -- >>> 1 `packedDoubles` [1, 2, 3]
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\n\CAN\NUL\NUL\NUL\NUL\NUL\NUL\240?\NUL\NUL\NUL\NUL\NUL\NUL\NUL@\NUL\NUL\NUL\NUL\NUL\NUL\b@"
-packedDoubles :: Foldable f => FieldNumber -> f Double -> Message
-packedDoubles num = embedded num . foldMap (Message . WB.doubleLE)
+packedDoubles :: Foldable f => FieldNumber -> f Double -> MessageBuilder
+packedDoubles num = embedded num . foldMap (MessageBuilder . WB.doubleLE)
 
 -- | Encode an embedded message.
 --
--- The message is represented as a 'Message', so it is possible to chain
+-- The message is represented as a 'MessageBuilder', so it is possible to chain
 -- encoding functions.
 --
 -- For example:
 --
 -- >>> 1 `embedded` (1 `string` "this message" <> 2 `string` " is embedded")
 -- Proto3.Wire.Encode.unsafeFromLazyByteString "\n\FS\n\fthis message\DC2\f is embedded"
-embedded :: FieldNumber -> Message -> Message
+embedded :: FieldNumber -> MessageBuilder -> MessageBuilder
 embedded num bb = fieldHeader num LengthDelimited <>
     base128Varint (fromIntegral (messageLength bb)) <>
     bb

--- a/src/Proto3/Wire/Tutorial.hs
+++ b/src/Proto3/Wire/Tutorial.hs
@@ -47,7 +47,7 @@
 -- To encode an 'EchoRequest', we use the @Encode.'Encode.text'@ function, and provide
 -- the field number and the text value:
 --
--- > encodeEchoRequest :: EchoRequest -> Encode.Builder
+-- > encodeEchoRequest :: EchoRequest -> Encode.Message
 -- > encodeEchoRequest EchoRequest{..} =
 -- >     Encode.text 1 echoRequestMessage
 --
@@ -93,10 +93,10 @@
 -- == Encoding
 --
 -- To encode messages with multiple fields, note that functions in the
--- "Proto3.Wire.Encode" module return values in the 'Encode.Builder' monoid,
+-- "Proto3.Wire.Encode" module return values in the 'Encode.Message' monoid,
 -- so we can use `mappend` to combine messages:
 --
--- > encodedEchoResponse :: EchoResponse -> Encode.Builder
+-- > encodedEchoResponse :: EchoResponse -> Encode.Message
 -- > encodedEchoResponse EchoResponse{..} =
 -- >     Encode.text 1 echoResponseMessage <>
 -- >         Encode.uint64 2 echoResponseTimestamp
@@ -136,14 +136,14 @@
 -- Messages can be embedded using `Encode.embedded`.
 --
 -- In protocol buffers version 3, all fields are optional. To omit a value for a
--- field, simply do not append it to the 'Encode.Builder'.
+-- field, simply do not append it to the 'Encode.Message'.
 --
 -- Similarly, repeated fields can be encoded by concatenating several values
 -- with the same 'FieldNumber'.
 --
 -- It can be useful to use 'foldMap' to deal with these cases.
 --
--- > encodeEchoManyRequest :: EchoManyRequest -> Encode.Builder
+-- > encodeEchoManyRequest :: EchoManyRequest -> Encode.Message
 -- > encodeEchoManyRequest =
 -- >   foldMap (Encode.embedded 1 . encodeEchoRequest)
 -- >   . echoManyRequestRequests
@@ -178,7 +178,7 @@ import qualified Proto3.Wire.Decode      as Decode
 
 data EchoRequest = EchoRequest { echoRequestMessage :: Text }
 
-encodeEchoRequest :: EchoRequest -> Encode.Builder
+encodeEchoRequest :: EchoRequest -> Encode.Message
 encodeEchoRequest EchoRequest{..} =
     Encode.text 1 echoRequestMessage
 
@@ -192,7 +192,7 @@ data EchoResponse = EchoResponse { echoResponseMessage   :: Text
                                  , echoResponseTimestamp :: Word64
                                  }
 
-encodedEchoResponse :: EchoResponse -> Encode.Builder
+encodedEchoResponse :: EchoResponse -> Encode.Message
 encodedEchoResponse EchoResponse{..} =
     Encode.text 1 echoResponseMessage <>
         Encode.uint64 2 echoResponseTimestamp
@@ -207,7 +207,7 @@ echoResponseParser = EchoResponse <$> (one Decode.text mempty `at` 1)
 data EchoManyRequest = EchoManyRequest { echoManyRequestRequests :: Seq EchoRequest
                                        }
 
-encodeEchoManyRequest :: EchoManyRequest -> Encode.Builder
+encodeEchoManyRequest :: EchoManyRequest -> Encode.Message
 encodeEchoManyRequest = foldMap (Encode.embedded 1 .
                                      encodeEchoRequest) .
     echoManyRequestRequests

--- a/src/Proto3/Wire/Tutorial.hs
+++ b/src/Proto3/Wire/Tutorial.hs
@@ -47,7 +47,7 @@
 -- To encode an 'EchoRequest', we use the @Encode.'Encode.text'@ function, and provide
 -- the field number and the text value:
 --
--- > encodeEchoRequest :: EchoRequest -> Encode.Message
+-- > encodeEchoRequest :: EchoRequest -> Encode.MessageBuilder
 -- > encodeEchoRequest EchoRequest{..} =
 -- >     Encode.text 1 echoRequestMessage
 --
@@ -93,10 +93,10 @@
 -- == Encoding
 --
 -- To encode messages with multiple fields, note that functions in the
--- "Proto3.Wire.Encode" module return values in the 'Encode.Message' monoid,
--- so we can use `mappend` to combine messages:
+-- "Proto3.Wire.Encode" module return values in the 'Encode.MessageBuilder'
+-- monoid, so we can use `mappend` to combine messages:
 --
--- > encodedEchoResponse :: EchoResponse -> Encode.Message
+-- > encodedEchoResponse :: EchoResponse -> Encode.MessageBuilder
 -- > encodedEchoResponse EchoResponse{..} =
 -- >     Encode.text 1 echoResponseMessage <>
 -- >         Encode.uint64 2 echoResponseTimestamp
@@ -136,14 +136,14 @@
 -- Messages can be embedded using `Encode.embedded`.
 --
 -- In protocol buffers version 3, all fields are optional. To omit a value for a
--- field, simply do not append it to the 'Encode.Message'.
+-- field, simply do not append it to the 'Encode.MessageBuilder'.
 --
 -- Similarly, repeated fields can be encoded by concatenating several values
 -- with the same 'FieldNumber'.
 --
 -- It can be useful to use 'foldMap' to deal with these cases.
 --
--- > encodeEchoManyRequest :: EchoManyRequest -> Encode.Message
+-- > encodeEchoManyRequest :: EchoManyRequest -> Encode.MessageBuilder
 -- > encodeEchoManyRequest =
 -- >   foldMap (Encode.embedded 1 . encodeEchoRequest)
 -- >   . echoManyRequestRequests
@@ -178,7 +178,7 @@ import qualified Proto3.Wire.Decode      as Decode
 
 data EchoRequest = EchoRequest { echoRequestMessage :: Text }
 
-encodeEchoRequest :: EchoRequest -> Encode.Message
+encodeEchoRequest :: EchoRequest -> Encode.MessageBuilder
 encodeEchoRequest EchoRequest{..} =
     Encode.text 1 echoRequestMessage
 
@@ -192,7 +192,7 @@ data EchoResponse = EchoResponse { echoResponseMessage   :: Text
                                  , echoResponseTimestamp :: Word64
                                  }
 
-encodedEchoResponse :: EchoResponse -> Encode.Message
+encodedEchoResponse :: EchoResponse -> Encode.MessageBuilder
 encodedEchoResponse EchoResponse{..} =
     Encode.text 1 echoResponseMessage <>
         Encode.uint64 2 echoResponseTimestamp
@@ -207,7 +207,7 @@ echoResponseParser = EchoResponse <$> (one Decode.text mempty `at` 1)
 data EchoManyRequest = EchoManyRequest { echoManyRequestRequests :: Seq EchoRequest
                                        }
 
-encodeEchoManyRequest :: EchoManyRequest -> Encode.Message
+encodeEchoManyRequest :: EchoManyRequest -> Encode.MessageBuilder
 encodeEchoManyRequest = foldMap (Encode.embedded 1 .
                                      encodeEchoRequest) .
     echoManyRequestRequests

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -114,7 +114,7 @@ roundTripTests = testGroup "Roundtrip tests"
 
 roundTrip :: (Show a, Eq a, Arbitrary a)
           => String
-          -> (a -> Encode.Builder)
+          -> (a -> Encode.Message)
           -> Decode.Parser Decode.RawMessage a
           -> TestTree
 roundTrip name encode decode =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -114,7 +114,7 @@ roundTripTests = testGroup "Roundtrip tests"
 
 roundTrip :: (Show a, Eq a, Arbitrary a)
           => String
-          -> (a -> Encode.Message)
+          -> (a -> Encode.MessageBuilder)
           -> Decode.Parser Decode.RawMessage a
           -> TestTree
 roundTrip name encode decode =


### PR DESCRIPTION
After talking with @j6carey he convinced me to restore the `Builder` newtype but
under a different name

This essentially reverts #18 but renames the newtype to `Message` and provides
an unsafe primitive for building a `Message` from bytes for the `Show` instance