### PR TITLE
Fix field ordering bug introduced by PR#12

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -41,6 +41,7 @@ main = do
       [ "-isrc"
       , "src/Proto3/Wire/Builder.hs"
       , "src/Proto3/Wire/Encode.hs"
+      , "src/Proto3/Wire/Decode.hs"
       ]
     defaultMain tests
 


### PR DESCRIPTION
Although https://github.com/awakenetworks/proto3-wire/pull/12 fixes `getFields` to correctly handle non-contiguous key repetition, it didn't maintain the invariant that field numbers were presented in their original order. This PR fixes this and adds some doctests.
